### PR TITLE
fix: 해시태그 정규식 수정 (콴다-커뮤니티 기준) / Example 수정

### DIFF
--- a/ActiveLabel/RegexParser.swift
+++ b/ActiveLabel/RegexParser.swift
@@ -10,7 +10,8 @@ import Foundation
 
 struct RegexParser {
 
-    static let hashtagPattern = "(?:^|\\s|$)#[\\p{L}0-9_]*"
+  // 원 라이브러리에서는 hashtagPattern = "(?:^|\\s|$)#[\\p{L}0-9_]*"였으나 콴다에서 필요로 의해 변경
+    static let hashtagPattern = "#([^\\W]+)"
     static let mentionPattern = "(?:^|\\s|$|[.])@[\\p{L}0-9_]*"
     static let emailPattern = "[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,64}"
     static let urlPattern = "(^|[\\s.:;?\\-\\]<\\(])" +

--- a/ActiveLabelDemo/ViewController.swift
+++ b/ActiveLabelDemo/ViewController.swift
@@ -27,9 +27,10 @@ class ViewController: UIViewController {
         label.urlMaximumLength = 31
 
         label.customize { label in
-            label.text = "This is a post with #multiple #hashtags and a @userhandle. Links are also supported like" +
-            " this one: http://optonaut.co. Now it also supports custom patterns -> are\n\n" +
-                "Let's trim a long link: \nhttps://twitter.com/twicket_app/status/649678392372121601"
+            label.text = "This is a post with #multiple #hashtags and a @userhandle. Linksare#Hashtag #해시태그#테스트 are also supported like\n" +
+              "Test00#Test01#Test테스트02.helloWorld!\n" +
+              " this one: http://optonaut.co. Now it also supports custom patterns -> are\n\n" +
+                  "Let's trim a long link: \nhttps://twitter.com/twicket_app/status/649678392372121601"
             label.numberOfLines = 0
             label.lineSpacing = 4
             
@@ -50,16 +51,16 @@ class ViewController: UIViewController {
             label.customColor[customType2] = UIColor.magenta
             label.customSelectedColor[customType2] = UIColor.green
             
-            label.configureLinkAttribute = { (type, attributes, isSelected) in
-                var atts = attributes
-                switch type {
-                case customType3:
-                    atts[NSAttributedString.Key.font] = isSelected ? UIFont.boldSystemFont(ofSize: 16) : UIFont.boldSystemFont(ofSize: 14)
-                default: ()
-                }
-                
-                return atts
-            }
+//            label.configureLinkAttribute = { (type, attributes, isSelected) in
+//                var atts = attributes
+//                switch type {
+//                case customType3:
+//                    atts[NSAttributedString.Key.font] = isSelected ? UIFont.boldSystemFont(ofSize: 16) : UIFont.boldSystemFont(ofSize: 14)
+//                default: ()
+//                }
+//
+//                return atts
+//            }
 
             label.handleCustomTap(for: customType) { self.alert("Custom type", message: $0) }
             label.handleCustomTap(for: customType2) { self.alert("Custom type", message: $0) }


### PR DESCRIPTION
## Feature
- 콴다 커뮤니티가 원하는 기능에 맞춰 해시태그 알고리즘 변경

## Before → After (해시태그로 인식된 텍스트가 다름)
<div>
<img src="https://user-images.githubusercontent.com/8576087/111097780-84cb6980-8585-11eb-8992-f33804f900c4.png" width="300">
<img src="https://user-images.githubusercontent.com/8576087/111097688-5a79ac00-8585-11eb-8ea0-dd7dbcd4bc7e.png" width="300">
</div>
